### PR TITLE
NETStandard compatibility

### DIFF
--- a/Blake2B.cs
+++ b/Blake2B.cs
@@ -371,7 +371,11 @@ namespace Crypto
 			return Final();
 		}
 
+#if NETSTANDARD1_6
+		public byte[] Hash
+#else
 		public override byte[] Hash
+#endif
 		{
 			get {
 				// if (m_bDisposed) throw new ObjectDisposedException(null);

--- a/Blake2S.cs
+++ b/Blake2S.cs
@@ -360,8 +360,11 @@ namespace Crypto
 			Core(sourceCode, 0, sourceCode.Length);
 			return Final();
 		}
-
+#if NETSTANDARD1_6
+		public byte[] Hash
+#else
 		public override byte[] Hash
+#endif
 		{
 			get {
 				// if (m_bDisposed) throw new ObjectDisposedException(null);


### PR DESCRIPTION
Currently I'm just using the repository as a submodule in my [project ](https://github.com/multiformats/cs-multihash) as your implementation does not currently support .net core. The NETStandard library version of HashAlgorithm does not implement "byte[] Hash" property, so added a conditional. If you're interested I'd might help out migrating the project to .net core, so I can depend on it by nuget.